### PR TITLE
Add observable jupyter-execute-agent notebook runner

### DIFF
--- a/.claude/docs/notebook-execution.md
+++ b/.claude/docs/notebook-execution.md
@@ -1,0 +1,97 @@
+# Running notebooks observably
+
+Read this when creating or executing Jupyter notebooks, especially long
+backtest, grid search, or optimiser runs that an agent needs to watch.
+
+## Observability requirements
+
+- All notebook cells must be observable, with `print()` and a
+  [`tqdm_loggable`](https://github.com/tradingstrategy-ai/tqdm-loggable) progress
+  bar for any operation longer than one minute.
+- Each long-running cell should print an estimate of how many minutes it will
+  still be running.
+- Prefer table output (Pandas DataFrame + `display()`) over `print()` for
+  tabular results.
+
+## Preferred entrypoint: `jupyter-execute-agent`
+
+The preferred command-line entrypoint is `jupyter-execute-agent`. It keeps the
+Jupyter-kernel execution model while making slow notebooks observable:
+notebook-level and cell-level progress, live cell output previews, live
+`tqdm` progress-bar text, and a partial save after every completed code cell.
+On operating systems whose shell supports it, the Python kernel is started with
+a 24 GiB virtual-memory cap so a runaway cell fails inside the kernel instead of
+exhausting the host.
+
+```shell
+# Run in-place, streaming progress to the terminal.
+poetry run jupyter-execute-agent notebooks/single-backtest/moving-average.ipynb
+```
+
+Useful flags:
+
+- `--output PATH` — write the executed notebook somewhere else instead of
+  overwriting in place.
+- `--timeout SECONDS` — per-cell timeout. Omit for the nbclient default; use a
+  large value (or run without a timeout) for long optimisers.
+- `--allow-errors` — keep executing after a cell raises.
+- `--no-save-every-cell` — only save once at the end instead of after each cell.
+- `--no-stream-cell-outputs` — quieter logs; only lifecycle events.
+
+Because the runner saves after every completed cell, if a long notebook crashes
+you still get every output produced up to the failing cell.
+
+### tqdm progress must reach the terminal
+
+All notebooks use `tqdm_loggable`. Force terminal progress output and keep the
+command in the foreground so the progress bar is visible from the calling
+terminal:
+
+```shell
+TQDM_LOGGABLE_FORCE=stdout poetry run jupyter-execute-agent my-notebook.ipynb
+```
+
+Do not rely on notebook widgets alone.
+
+## Plain fallback
+
+For a plain, non-observable run, `poetry run jupyter execute my-notebook.ipynb --inplace`
+still works, but prefer `jupyter-execute-agent` for anything an agent needs to
+watch.
+
+Never use `ipython` to run notebooks — it forces single-process execution and
+breaks multiprocessing. Use it only for targeted debugging of extracted code.
+
+## Running multiple notebooks
+
+When running multiple notebooks with subagents, use at most 3 agents at a time
+to avoid exhausting RAM and crashing the machine. If several agents run
+notebooks concurrently, never kill all `ipykernel` processes broadly — identify
+the exact `jupyter-execute-agent ... my-notebook.ipynb` parent process first,
+then match its child kernel by PID before killing anything.
+
+## Programmatic use
+
+The same execution flow is importable for tests and scripts:
+
+```python
+import logging
+from pathlib import Path
+
+from getting_started.jupyter_execute_agent import execute_notebook_observable
+from getting_started.jupyter_execute_agent import build_logging_observer
+
+result = execute_notebook_observable(
+    Path("notebooks/single-backtest/moving-average.ipynb"),
+    observers=[build_logging_observer(logger=logging.getLogger("notebook"))],
+)
+print(result.executed_code_cells, result.total_elapsed_seconds)
+```
+
+`execute_notebook_observable()` emits structured
+`NotebookExecutionEvent` objects (`notebook_started`, `cell_started`,
+`cell_output`, `cell_completed`, `cell_failed`, `notebook_saved`,
+`notebook_completed`) to any observer callback, which is what makes runs
+observable and testable. See
+[tests/test_jupyter_execute_agent.py](../../tests/test_jupyter_execute_agent.py)
+for a minimal observability regression test.

--- a/.claude/skills/convert-to-backtest/SKILL.md
+++ b/.claude/skills/convert-to-backtest/SKILL.md
@@ -174,7 +174,7 @@ A Python script [build_backtest_notebook.py](build_backtest_notebook.py) (in the
    - No `float()` casts around parameter values that are now native Python types
    - No dynamic dispatch for parameters that are now fixed values
    - All chart rendering cells reference `chart_renderer`
-   - Test run: `poetry run jupyter execute {output-notebook}.ipynb --inplace --timeout=900`
+   - Test run with the observable runner: `poetry run jupyter-execute-agent {output-notebook}.ipynb --timeout=900`. See [notebook-execution.md](../../docs/notebook-execution.md).
 
 7. **Verify results match the optimiser's best pick**: After running the notebook, compare the backtest metrics (CAGR, Sharpe, max drawdown) with the optimiser's best result. The values should match exactly or near-exactly:
    - **CAGR**: Should match to within 1% absolute (e.g. 40.8% vs 40.8%).

--- a/.claude/skills/convert-to-optimiser/SKILL.md
+++ b/.claude/skills/convert-to-optimiser/SKILL.md
@@ -121,7 +121,7 @@ Convert a single backtesting notebook into an optimiser notebook that optimises 
    - `create_trading_universe()` and `decide_trades()` are unchanged from the backtest
    - Optimiser cell uses `perform_optimisation` with `prepare_optimiser_parameters(Parameters)`
    - All output cells match the reference optimiser structure
-   - Test run: `poetry run jupyter execute {output-notebook}.ipynb --inplace --timeout=-1`
+   - Test run with the observable runner: `poetry run jupyter-execute-agent {output-notebook}.ipynb` (omit `--timeout` for long optimisers). See [notebook-execution.md](../../docs/notebook-execution.md).
 
 ## Cell-by-cell mapping
 

--- a/.claude/skills/create-variant/SKILL.md
+++ b/.claude/skills/create-variant/SKILL.md
@@ -45,7 +45,7 @@ If the original notebook uses an optimiser (e.g. `perform_optimisation` with an 
 
 ## Verification
 
-After the notebook is created, run it with `jupyter execute` as instructions in CLAUDE.md. Fix any bugs and issues you may have created.
+After the notebook is created, run it with the observable `jupyter-execute-agent` runner as instructed in CLAUDE.md — `poetry run jupyter-execute-agent {output-notebook}.ipynb` (see [notebook-execution.md](../../docs/notebook-execution.md)). Fix any bugs and issues you may have created.
 
 ## Analysis
 

--- a/.claude/skills/run-variant-cycle/SKILL.md
+++ b/.claude/skills/run-variant-cycle/SKILL.md
@@ -48,7 +48,9 @@ If the original notebook uses an optimiser (e.g. `perform_optimisation` with an 
 
 ## 3. Execute notebook
 
-Run the notebook using as described in CLAUDE.md using a subagent.
+Run the notebook with the observable `jupyter-execute-agent` runner as described
+in CLAUDE.md, using a subagent — `poetry run jupyter-execute-agent {notebook}.ipynb`
+(see [notebook-execution.md](../../docs/notebook-execution.md)).
 If there are any bugs, make sure subagent fixed them and rerun the notebook again.
 
 ## 4. Analysis

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,17 +16,27 @@ When adding or updating a skill, edit the files under `.claude/skills/` and keep
 
 ## Running notebooks
 
-You can test if a notebook runs from the command line with `jupyter` command.
+The preferred way to run a notebook from the command line is the observable
+`jupyter-execute-agent` runner. It keeps the Jupyter-kernel execution model but
+streams notebook- and cell-level progress, live cell output previews, and live
+`tqdm` progress text, and saves the notebook after every completed cell so a
+crash still leaves you every output up to the failing cell. Read
+[notebook-execution.md](.claude/docs/notebook-execution.md) for the full command
+reference.
 
 Example:
 
 ```shell
-poetry run jupyter execute my-notebook.ipynb --inplace --timeout=900
+poetry run jupyter-execute-agent my-notebook.ipynb
 ```
 
-- `--inplace` overwrites the notebook with executed results (cell outputs)
-- `--timeout=900` sets a 15 minute per-cell execution timeout (use `-1` to disable for long-running optimisers)
+- Saves in place after every completed code cell by default (use `--output PATH` to write elsewhere, `--no-save-every-cell` to save only at the end)
+- Add `--timeout=900` for a 15 minute per-cell timeout; omit it for long-running optimisers
+- Applies a 24 GiB kernel memory cap where the OS shell supports it
 
+Plain `poetry run jupyter execute my-notebook.ipynb --inplace` still works as a
+non-observable fallback, but prefer `jupyter-execute-agent` for anything an agent
+needs to watch.
 
 Never use `ipython` command as it does not work with multiprocessing.
 
@@ -39,7 +49,7 @@ When running multiple notebooks with subagents, use max 3 agents to avoid exhaus
 All notebooks use [`tqdm_loggable`](https://github.com/tradingstrategy-ai/tqdm-loggable). Always use `TQDM_LOGGABLE_FORCE=stdout` and keep the command in the foreground:
 
 ```shell
-TQDM_LOGGABLE_FORCE=stdout poetry run jupyter execute my-notebook.ipynb --inplace --timeout=900
+TQDM_LOGGABLE_FORCE=stdout poetry run jupyter-execute-agent my-notebook.ipynb
 ```
 
 This forces terminal progress output so the optimiser progress bar is visible from the calling terminal. Do not rely on notebook widgets alone.
@@ -55,11 +65,11 @@ Follow the [notebook server instructions](.claude/docs/notebook-server.md) for t
 If multiple agents are running notebooks concurrently:
 
 - Never kill all `ipykernel` processes broadly
-- Identify the exact `jupyter execute ... my-notebook.ipynb` parent process first, then match its child kernel by PID/start time
+- Identify the exact `jupyter-execute-agent ... my-notebook.ipynb` parent process first, then match its child kernel by PID/start time
 - If kernel ownership is ambiguous, do not kill any — prefer leaving a stale kernel over killing another agent's live backtest
 
 ```shell
-ps -Ao pid,ppid,%cpu,etime,command | rg 'jupyter-execute|ipykernel|ipykernel_launcher'
+ps -Ao pid,ppid,%cpu,etime,command | rg 'jupyter-execute-agent|jupyter-execute|ipykernel|ipykernel_launcher'
 ```
 
 ## Running Python scripts

--- a/getting_started/jupyter_execute_agent/__init__.py
+++ b/getting_started/jupyter_execute_agent/__init__.py
@@ -1,0 +1,38 @@
+"""Observable Jupyter notebook execution helpers.
+
+This package provides a small reusable execution agent for running notebooks
+cell-by-cell with explicit progress events, partial-save support, and logging
+extensions suitable for long-running research workflows.
+"""
+
+from .core import NotebookCellRecord
+from .core import NotebookExecutionEvent
+from .core import NotebookExecutionResult
+from .core import DEFAULT_KERNEL_MEMORY_LIMIT_BYTES
+from .core import build_cell_label
+from .core import execute_notebook_observable
+from .core import iter_code_cells
+from .core import load_notebook_document
+from .core import save_notebook_document
+from .cli import build_argument_parser
+from .cli import main
+from .extension import build_logging_observer
+from .extension import format_execution_event
+from .extension import log_execution_event
+
+__all__ = [
+    "NotebookCellRecord",
+    "NotebookExecutionEvent",
+    "NotebookExecutionResult",
+    "DEFAULT_KERNEL_MEMORY_LIMIT_BYTES",
+    "build_argument_parser",
+    "build_cell_label",
+    "build_logging_observer",
+    "execute_notebook_observable",
+    "format_execution_event",
+    "iter_code_cells",
+    "load_notebook_document",
+    "log_execution_event",
+    "main",
+    "save_notebook_document",
+]

--- a/getting_started/jupyter_execute_agent/cli.py
+++ b/getting_started/jupyter_execute_agent/cli.py
@@ -1,0 +1,130 @@
+"""Command-line entrypoint for observable notebook execution.
+
+This module exposes a small Poetry script wrapper around
+``execute_notebook_observable()`` so notebook runs can use the same
+high-observability execution flow from the shell.
+"""
+
+import argparse
+from pathlib import Path
+import logging
+import sys
+
+from .core import execute_notebook_observable
+from .extension import build_logging_observer
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    """Create the CLI argument parser for the observable notebook runner.
+
+    Example:
+
+    .. code-block:: python
+
+        parser = build_argument_parser()
+        namespace = parser.parse_args(["notebooks/demo.ipynb", "--save-every-cell"])
+
+    :return:
+        Configured argument parser.
+    """
+
+    parser = argparse.ArgumentParser(
+        prog="jupyter-execute-agent",
+        description="Execute a Jupyter notebook cell-by-cell with observable logs.",
+    )
+    parser.add_argument(
+        "notebook_path",
+        type=Path,
+        help="Notebook file to execute.",
+    )
+    parser.add_argument(
+        "--output",
+        dest="output_path",
+        type=Path,
+        help="Destination executed notebook path. Defaults to in-place save.",
+    )
+    parser.add_argument(
+        "--cwd",
+        type=Path,
+        help="Kernel working directory. Defaults to the notebook parent.",
+    )
+    parser.add_argument(
+        "--kernel-name",
+        default="python3",
+        help="Jupyter kernel name to use. Default: python3.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=None,
+        help="Per-cell timeout in seconds. Default: nbclient default.",
+    )
+    parser.add_argument(
+        "--allow-errors",
+        action="store_true",
+        help="Continue execution when a cell raises an error.",
+    )
+    parser.add_argument(
+        "--save-every-cell",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Save the notebook after every completed code cell. Default: true.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level for progress events. Default: INFO.",
+    )
+    parser.add_argument(
+        "--stream-cell-outputs",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Log cell stdout/stderr/result payloads as they arrive. Default: true.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the observable notebook CLI.
+
+    Example:
+
+    .. code-block:: shell
+
+        poetry run jupyter-execute-agent notebooks/demo.ipynb --save-every-cell
+
+    :param argv:
+        Optional explicit argument vector, excluding the executable name.
+    :return:
+        Process exit code, where ``0`` means success.
+    """
+
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(message)s",
+    )
+
+    execute_notebook_observable(
+        args.notebook_path,
+        output_path=args.output_path,
+        cwd=args.cwd,
+        kernel_name=args.kernel_name,
+        timeout=args.timeout,
+        allow_errors=args.allow_errors,
+        save_every_cell=args.save_every_cell,
+        observers=[
+            build_logging_observer(
+                logger=logging.getLogger(__name__),
+                stream_cell_outputs=args.stream_cell_outputs,
+            )
+        ],
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/getting_started/jupyter_execute_agent/core.py
+++ b/getting_started/jupyter_execute_agent/core.py
@@ -1,0 +1,1074 @@
+"""Core helpers for observable Jupyter notebook execution.
+
+The functions in this module are designed for long-running notebook workflows
+where plain ``jupyter execute`` is too opaque. The execution loop emits
+structured events before and after each code cell, can save the partially
+executed notebook after every completed cell, and keeps enough timing
+information for human-friendly progress reporting.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import lru_cache
+import html
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, Iterator, Literal, Sequence
+
+from jupyter_client.manager import KernelManager
+import nbformat
+from nbclient import NotebookClient
+from nbclient.client import output_from_msg
+from nbclient.exceptions import CellExecutionError
+from nbformat import NotebookNode
+
+
+EventKind = Literal[
+    "notebook_started",
+    "cell_started",
+    "cell_output",
+    "cell_completed",
+    "cell_failed",
+    "notebook_saved",
+    "notebook_completed",
+]
+
+#: Default address-space cap for local Python Jupyter kernels so large
+#: notebooks fail inside the kernel before exhausting the host.
+DEFAULT_KERNEL_MEMORY_LIMIT_BYTES = 24 * 1024 * 1024 * 1024
+
+#: Shell path used for applying the memory cap before the Python kernel starts.
+_KERNEL_MEMORY_LIMIT_SHELL = "/bin/sh"
+
+#: Shell snippet used because ``ulimit`` is a shell builtin on common POSIX systems.
+_KERNEL_MEMORY_LIMIT_SCRIPT = (
+    'limit_kbytes="$1"\n'
+    "shift\n"
+    'ulimit -v "$limit_kbytes" || exit 126\n'
+    'exec "$@"\n'
+)
+
+__all__ = [
+    "DEFAULT_KERNEL_MEMORY_LIMIT_BYTES",
+    "NotebookCellRecord",
+    "NotebookExecutionEvent",
+    "NotebookExecutionObserver",
+    "NotebookExecutionResult",
+    "build_cell_label",
+    "execute_notebook_observable",
+    "iter_code_cells",
+    "load_notebook_document",
+    "save_notebook_document",
+]
+
+
+@dataclass(slots=True, frozen=True)
+class NotebookExecutionEvent:
+    """One structured notebook-execution event.
+
+    :ivar kind:
+        Event kind such as ``"cell_started"`` or ``"cell_completed"``.
+    :ivar notebook_path:
+        Source notebook path.
+    :ivar output_path:
+        Destination notebook path written during execution.
+    :ivar cell_index:
+        Zero-based absolute cell index inside the notebook, or ``None`` for
+        notebook-level events.
+    :ivar code_cell_index:
+        One-based code-cell position among code cells only, or ``None`` for
+        notebook-level events.
+    :ivar total_code_cells:
+        Total number of code cells in the notebook.
+    :ivar cell_label:
+        Short cell label derived from the cell source.
+    :ivar started_at:
+        UTC timestamp when the event scope started.
+    :ivar finished_at:
+        UTC timestamp when the event scope finished.
+    :ivar elapsed_seconds:
+        Duration in seconds for the event scope.
+    :ivar execution_count:
+        Jupyter execution count written to the cell, if available.
+    :ivar output_preview:
+        Short preview of the cell output payload, if any.
+    :ivar output_type:
+        Jupyter output payload type for live ``"cell_output"`` events.
+    :ivar error_name:
+        Jupyter error name for failed cells, if available.
+    :ivar error_value:
+        Jupyter error value for failed cells, if available.
+    """
+
+    kind: EventKind
+    notebook_path: Path
+    output_path: Path
+    cell_index: int | None = None
+    code_cell_index: int | None = None
+    total_code_cells: int | None = None
+    cell_label: str | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    elapsed_seconds: float | None = None
+    execution_count: int | None = None
+    output_preview: str | None = None
+    output_type: str | None = None
+    error_name: str | None = None
+    error_value: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class NotebookCellRecord:
+    """Summary record for one executed code cell.
+
+    :ivar cell_index:
+        Zero-based absolute notebook cell index.
+    :ivar code_cell_index:
+        One-based code-cell position among code cells only.
+    :ivar label:
+        Human-friendly cell label derived from the source.
+    :ivar status:
+        Final status, typically ``"completed"`` or ``"failed"``.
+    :ivar elapsed_seconds:
+        Cell execution time in seconds.
+    :ivar execution_count:
+        Jupyter execution counter written to the cell.
+    :ivar output_preview:
+        Short output preview extracted from the executed cell.
+    """
+
+    cell_index: int
+    code_cell_index: int
+    label: str
+    status: Literal["completed", "failed"]
+    elapsed_seconds: float
+    execution_count: int | None
+    output_preview: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class NotebookExecutionResult:
+    """Summary of an observable notebook execution run.
+
+    :ivar notebook_path:
+        Source notebook path.
+    :ivar output_path:
+        Final saved notebook path.
+    :ivar started_at:
+        UTC start timestamp.
+    :ivar finished_at:
+        UTC end timestamp.
+    :ivar total_elapsed_seconds:
+        Total notebook execution time in seconds.
+    :ivar total_code_cells:
+        Total number of code cells discovered before execution.
+    :ivar executed_code_cells:
+        Number of code cells that finished execution.
+    :ivar cell_records:
+        Per-cell execution summaries in completion order.
+    """
+
+    notebook_path: Path
+    output_path: Path
+    started_at: datetime
+    finished_at: datetime
+    total_elapsed_seconds: float
+    total_code_cells: int
+    executed_code_cells: int
+    cell_records: tuple[NotebookCellRecord, ...]
+
+
+type NotebookExecutionObserver = Callable[[NotebookExecutionEvent], None]
+
+
+class ObservableNotebookClient(NotebookClient):
+    """Notebook client that emits observer events for live cell outputs."""
+
+    def __init__(
+        self,
+        *args: Any,
+        output_observer: Callable[[NotebookNode, int], None] | None = None,
+        kernel_memory_limit_bytes: int | None = DEFAULT_KERNEL_MEMORY_LIMIT_BYTES,
+        **kwargs: Any,
+    ) -> None:
+        kwargs.setdefault("kernel_manager_class", MemoryLimitedKernelManager)
+        super().__init__(*args, **kwargs)
+        self._output_observer = output_observer
+        self._kernel_memory_limit_bytes = kernel_memory_limit_bytes
+        self._widget_progress_tracker = _WidgetProgressTracker()
+
+    def create_kernel_manager(self) -> KernelManager:
+        """Create a kernel manager configured for observable execution.
+
+        The base nbclient implementation owns kernel-manager construction. We
+        extend it only to pass the optional memory limit to our local manager
+        subclass after traitlets has instantiated the manager.
+
+        :return:
+            Configured kernel manager.
+        """
+
+        manager = super().create_kernel_manager()
+        if isinstance(manager, MemoryLimitedKernelManager):
+            manager.kernel_memory_limit_bytes = self._kernel_memory_limit_bytes
+        return manager
+
+    def process_message(
+        self,
+        msg: dict[str, Any],
+        cell: NotebookNode,
+        cell_index: int,
+    ) -> NotebookNode | None:
+        """Process a kernel message and notify callers about new outputs."""
+
+        output = super().process_message(msg, cell, cell_index)
+        if output is not None and self._output_observer is not None:
+            self._output_observer(output, cell_index)
+        if self._output_observer is not None:
+            live_output = self._build_live_output_from_message(msg)
+            if live_output is not None:
+                self._output_observer(live_output, cell_index)
+        return output
+
+    def _build_live_output_from_message(
+        self,
+        msg: dict[str, Any],
+    ) -> NotebookNode | None:
+        """Build a live output payload from non-append kernel messages.
+
+        ``nbclient`` returns appended outputs from :meth:`process_message`, but
+        notebook progress bars commonly refresh through ``update_display_data``
+        or ipywidgets ``comm_msg`` traffic. Those messages mutate earlier
+        outputs or widget state instead of appending a new output object, so
+        callers need a small translation layer for headless observability.
+
+        :param msg:
+            Raw kernel IOPub message.
+        :return:
+            Synthetic output node for observer callbacks, or ``None``.
+        """
+
+        msg_type = str(msg.get("msg_type", ""))
+        if msg_type == "update_display_data":
+            try:
+                return output_from_msg(msg)
+            except ValueError:
+                return None
+        if msg_type in {"comm_open", "comm_msg"}:
+            preview = self._widget_progress_tracker.update(msg)
+            if preview:
+                return NotebookNode(
+                    {
+                        "output_type": "widget_progress",
+                        "text": preview,
+                    }
+                )
+        return None
+
+
+class MemoryLimitedKernelManager(KernelManager):
+    """Kernel manager that applies an optional local-process memory cap."""
+
+    kernel_memory_limit_bytes: int | None = DEFAULT_KERNEL_MEMORY_LIMIT_BYTES
+
+    async def _async_pre_start_kernel(
+        self,
+        **kw: Any,
+    ) -> tuple[list[str], dict[str, Any]]:
+        """Prepare the kernel command and wrap it with ``ulimit`` when viable.
+
+        :param kw:
+            Kernel startup keyword arguments.
+        :return:
+            Kernel command and launch keyword arguments.
+        """
+
+        kernel_cmd, launch_kwargs = await super()._async_pre_start_kernel(**kw)
+        if _kernel_memory_limit_is_supported(self.kernel_memory_limit_bytes):
+            kernel_cmd = _wrap_kernel_command_with_memory_limit(
+                kernel_cmd,
+                self.kernel_memory_limit_bytes,
+            )
+        return kernel_cmd, launch_kwargs
+
+
+class _WidgetProgressTracker:
+    """Track ipywidgets progress bars and render them as compact text."""
+
+    _PROGRESS_MODELS = {"FloatProgressModel", "IntProgressModel"}
+    _HTML_MODELS = {"HTMLModel", "LabelModel"}
+    _CONTAINER_MODELS = {"HBoxModel", "VBoxModel"}
+
+    def __init__(self) -> None:
+        self._models: dict[str, dict[str, Any]] = {}
+        self._last_preview_by_container: dict[str, str] = {}
+
+    def update(self, msg: dict[str, Any]) -> str | None:
+        """Update widget state from one comm message and maybe render progress.
+
+        :param msg:
+            Raw ``comm_open`` or ``comm_msg`` kernel message.
+        :return:
+            Progress preview when a tqdm-like widget changed, otherwise
+            ``None``.
+        """
+
+        content = msg.get("content", {})
+        comm_id = str(content.get("comm_id", ""))
+        if not comm_id:
+            return None
+
+        msg_type = str(msg.get("msg_type", ""))
+        data = content.get("data", {})
+        if not isinstance(data, dict):
+            return None
+
+        if msg_type == "comm_open":
+            state = data.get("state", {})
+            if isinstance(state, dict):
+                self._models[comm_id] = dict(state)
+            return None
+
+        if msg_type != "comm_msg":
+            return None
+
+        state = data.get("state", {})
+        if isinstance(state, dict):
+            self._models.setdefault(comm_id, {}).update(state)
+
+        return self._build_preview_for_changed_model(comm_id)
+
+    def _build_preview_for_changed_model(self, comm_id: str) -> str | None:
+        """Render a tqdm widget when its right-hand status text changes."""
+
+        for container_id, container in self._models.items():
+            if not self._is_container_model(container):
+                continue
+            children = self._normalise_widget_children(container.get("children", []))
+            if comm_id not in children:
+                continue
+            progress_child_ids = [
+                child_id
+                for child_id in children
+                if self._is_progress_model(self._models.get(child_id, {}))
+            ]
+            if not progress_child_ids:
+                continue
+            html_child_ids = [
+                child_id
+                for child_id in children
+                if self._is_html_model(self._models.get(child_id, {}))
+            ]
+            if html_child_ids and comm_id != html_child_ids[-1]:
+                continue
+            preview = self._build_container_preview(children, progress_child_ids[0])
+            if not preview:
+                continue
+            if self._last_preview_by_container.get(container_id) == preview:
+                continue
+            self._last_preview_by_container[container_id] = preview
+            return preview
+        return None
+
+    def _build_container_preview(
+        self,
+        children: Sequence[str],
+        progress_child_id: str,
+    ) -> str | None:
+        """Build a text preview from a tqdm notebook widget container."""
+
+        progress = self._models.get(progress_child_id, {})
+        html_parts = [
+            self._normalise_widget_text(self._models[child_id].get("value", ""))
+            for child_id in children
+            if child_id in self._models and self._is_html_model(self._models[child_id])
+        ]
+        text = " ".join(part for part in html_parts if part).strip()
+        if not text:
+            text = self._build_progress_ratio(progress)
+        return text or None
+
+    def _build_progress_ratio(self, progress: dict[str, Any]) -> str:
+        """Build a fallback ``n/total`` text from a progress widget."""
+
+        value = progress.get("value")
+        total = progress.get("max")
+        if value is None or total is None:
+            return ""
+        try:
+            value_number = float(value)
+            total_number = float(total)
+        except (TypeError, ValueError):
+            return ""
+        if total_number <= 0:
+            return f"{value_number:g}"
+        percent = value_number / total_number * 100.0
+        return f"{percent:.0f}% {value_number:g}/{total_number:g}"
+
+    def _normalise_widget_children(self, children: object) -> tuple[str, ...]:
+        """Return comm ids from ``IPY_MODEL_*`` child references."""
+
+        if not isinstance(children, (list, tuple)):
+            return ()
+        return tuple(
+            str(child).removeprefix("IPY_MODEL_")
+            for child in children
+            if str(child).startswith("IPY_MODEL_")
+        )
+
+    def _normalise_widget_text(self, value: object) -> str:
+        """Convert widget HTML text to compact terminal text."""
+
+        text = html.unescape(str(value))
+        text = re.sub(r"<[^>]+>", "", text)
+        text = text.replace("\u2007", " ").replace("\xa0", " ")
+        return " ".join(text.split())
+
+    def _is_container_model(self, model: dict[str, Any]) -> bool:
+        """Return whether a widget model is a box container."""
+
+        return str(model.get("_model_name")) in self._CONTAINER_MODELS
+
+    def _is_progress_model(self, model: dict[str, Any]) -> bool:
+        """Return whether a widget model is a progress bar."""
+
+        return str(model.get("_model_name")) in self._PROGRESS_MODELS
+
+    def _is_html_model(self, model: dict[str, Any]) -> bool:
+        """Return whether a widget model carries display text."""
+
+        return str(model.get("_model_name")) in self._HTML_MODELS
+
+
+def load_notebook_document(notebook_path: Path) -> NotebookNode:
+    """Load a notebook document from disk.
+
+    Reads the notebook using ``nbformat`` version 4 so it can be passed
+    directly to :class:`nbclient.NotebookClient`.
+
+    Example:
+
+    .. code-block:: python
+
+        from pathlib import Path
+        from getting_started.jupyter_execute_agent import load_notebook_document
+
+        notebook = load_notebook_document(Path("notebooks/demo.ipynb"))
+
+    :param notebook_path:
+        Notebook file to load.
+    :return:
+        Parsed ``NotebookNode`` document.
+    """
+
+    with notebook_path.open("r", encoding="utf-8") as handle:
+        return nbformat.read(handle, as_version=4)
+
+
+def save_notebook_document(notebook: NotebookNode, output_path: Path) -> Path:
+    """Save a notebook document to disk.
+
+    Example:
+
+    .. code-block:: python
+
+        from pathlib import Path
+        from getting_started.jupyter_execute_agent import save_notebook_document
+
+        save_notebook_document(notebook, Path("notebooks/demo-executed.ipynb"))
+
+    :param notebook:
+        Parsed notebook document.
+    :param output_path:
+        Destination notebook path.
+    :return:
+        The written output path.
+    """
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
+        nbformat.write(notebook, handle)
+    return output_path
+
+
+def iter_code_cells(notebook: NotebookNode) -> Iterator[tuple[int, int, NotebookNode]]:
+    """Yield the code cells in notebook order.
+
+    The returned tuple contains ``(cell_index, code_cell_index, cell)`` where
+    ``cell_index`` is the absolute notebook index and ``code_cell_index`` is
+    one-based among code cells only.
+
+    Example:
+
+    .. code-block:: python
+
+        for cell_index, code_cell_index, cell in iter_code_cells(notebook):
+            print(cell_index, code_cell_index, cell.cell_type)
+
+    :param notebook:
+        Notebook document to inspect.
+    :return:
+        Iterator over code-cell tuples.
+    """
+
+    code_cell_index = 0
+    for cell_index, cell in enumerate(notebook.cells):
+        if cell.cell_type != "code":
+            continue
+        code_cell_index += 1
+        yield cell_index, code_cell_index, cell
+
+
+def build_cell_label(
+    cell: NotebookNode,
+    cell_index: int,
+    *,
+    max_chars: int = 96,
+) -> str:
+    """Build a compact label for one notebook cell.
+
+    The label uses the first non-empty source line when possible, falling back
+    to a synthetic ``Cell <n>`` label when the source is empty.
+
+    Example:
+
+    .. code-block:: python
+
+        label = build_cell_label(cell, 7)
+        print(label)
+
+    :param cell:
+        Notebook cell node.
+    :param cell_index:
+        Zero-based absolute cell index.
+    :param max_chars:
+        Maximum label length before truncation.
+    :return:
+        Human-readable cell label.
+    """
+
+    raw_source = str(cell.get("source", ""))
+    for line in raw_source.splitlines():
+        stripped = line.strip()
+        if stripped:
+            normalized = " ".join(stripped.split())
+            if len(normalized) <= max_chars:
+                return normalized
+            return normalized[: max_chars - 3] + "..."
+    return f"Cell {cell_index + 1}"
+
+
+def execute_notebook_observable(
+    notebook_path: Path,
+    *,
+    output_path: Path | None = None,
+    cwd: Path | None = None,
+    kernel_name: str = "python3",
+    kernel_memory_limit_bytes: int | None = DEFAULT_KERNEL_MEMORY_LIMIT_BYTES,
+    timeout: int | None = None,
+    allow_errors: bool = False,
+    save_every_cell: bool = True,
+    observers: Sequence[NotebookExecutionObserver] = (),
+    client_kwargs: dict[str, Any] | None = None,
+) -> NotebookExecutionResult:
+    """Execute a notebook cell-by-cell with structured progress events.
+
+    This is the main high-observability execution helper. It emits notebook and
+    cell events, optionally saves the notebook after each completed code cell,
+    and returns a summary object at the end. Failed cells are saved before the
+    original :class:`nbclient.exceptions.CellExecutionError` is re-raised.
+
+    Example:
+
+    .. code-block:: python
+
+        import logging
+        from pathlib import Path
+
+        from getting_started.jupyter_execute_agent import execute_notebook_observable
+        from getting_started.jupyter_execute_agent import build_logging_observer
+
+        logger = logging.getLogger("notebook-runner")
+        result = execute_notebook_observable(
+            Path("notebooks/demo.ipynb"),
+            output_path=Path("notebooks/demo-executed.ipynb"),
+            observers=[build_logging_observer(logger=logger)],
+            save_every_cell=True,
+        )
+        print(result.executed_code_cells, result.total_elapsed_seconds)
+
+    :param notebook_path:
+        Source notebook path to execute.
+    :param output_path:
+        Destination notebook path. Defaults to overwriting ``notebook_path``.
+    :param cwd:
+        Working directory exposed to the kernel via nbclient resources. Defaults
+        to the notebook's parent directory.
+    :param kernel_name:
+        Jupyter kernel name. Defaults to ``"python3"``.
+    :param kernel_memory_limit_bytes:
+        Address-space memory cap applied to the local kernel process before it
+        starts, when the operating system shell supports virtual-memory
+        limits. Defaults to 24 GiB. Use ``None`` to disable the cap.
+    :param timeout:
+        Per-cell timeout in seconds. ``None`` uses nbclient defaults.
+    :param allow_errors:
+        Forwarded to nbclient. If ``False``, execution stops on the first cell
+        error and re-raises ``CellExecutionError`` after saving the notebook.
+    :param save_every_cell:
+        If ``True``, save the notebook after every completed code cell.
+    :param observers:
+        Sequence of event callbacks invoked for notebook and cell lifecycle
+        events.
+    :param client_kwargs:
+        Additional keyword arguments forwarded to ``NotebookClient``.
+    :return:
+        Execution summary result.
+    """
+
+    source_path = notebook_path.resolve()
+    final_output_path = output_path.resolve() if output_path else source_path
+    notebook = load_notebook_document(source_path)
+    total_code_cells = sum(1 for _ in iter_code_cells(notebook))
+    active_cwd = (cwd or source_path.parent).resolve()
+    started_at = _utc_now()
+    start_perf = time.perf_counter()
+    observer_tuple = tuple(observers)
+    _validate_kernel_memory_limit(kernel_memory_limit_bytes)
+
+    _notify(
+        observer_tuple,
+        NotebookExecutionEvent(
+            kind="notebook_started",
+            notebook_path=source_path,
+            output_path=final_output_path,
+            total_code_cells=total_code_cells,
+            started_at=started_at,
+        ),
+    )
+
+    cell_labels: dict[int, str] = {}
+    code_cell_indexes: dict[int, int] = {}
+    for cell_index, code_cell_index, cell in iter_code_cells(notebook):
+        cell_labels[cell_index] = build_cell_label(cell, cell_index)
+        code_cell_indexes[cell_index] = code_cell_index
+
+    def _notify_live_output(output: NotebookNode, cell_index: int) -> None:
+        output_preview = _build_single_output_preview(output)
+        if output_preview is None:
+            return
+        _notify(
+            observer_tuple,
+            NotebookExecutionEvent(
+                kind="cell_output",
+                notebook_path=source_path,
+                output_path=final_output_path,
+                cell_index=cell_index,
+                code_cell_index=code_cell_indexes.get(cell_index),
+                total_code_cells=total_code_cells,
+                cell_label=cell_labels.get(cell_index),
+                finished_at=_utc_now(),
+                execution_count=_coerce_execution_count(notebook.cells[cell_index]),
+                output_preview=output_preview,
+                output_type=str(output.get("output_type", "")) or None,
+            ),
+        )
+
+    client = ObservableNotebookClient(
+        notebook,
+        timeout=timeout,
+        kernel_name=kernel_name,
+        allow_errors=allow_errors,
+        resources={"metadata": {"path": str(active_cwd)}},
+        output_observer=_notify_live_output,
+        kernel_memory_limit_bytes=kernel_memory_limit_bytes,
+        **(client_kwargs or {}),
+    )
+
+    cell_records: list[NotebookCellRecord] = []
+    executed_code_cells = 0
+
+    try:
+        with client.setup_kernel():
+            for cell_index, code_cell_index, cell in iter_code_cells(notebook):
+                label = cell_labels[cell_index]
+                cell_started_at = _utc_now()
+                cell_start_perf = time.perf_counter()
+                _notify(
+                    observer_tuple,
+                    NotebookExecutionEvent(
+                        kind="cell_started",
+                        notebook_path=source_path,
+                        output_path=final_output_path,
+                        cell_index=cell_index,
+                        code_cell_index=code_cell_index,
+                        total_code_cells=total_code_cells,
+                        cell_label=label,
+                        started_at=cell_started_at,
+                    ),
+                )
+                try:
+                    client.execute_cell(
+                        cell,
+                        cell_index,
+                        execution_count=code_cell_index,
+                    )
+                except CellExecutionError:
+                    cell_elapsed = time.perf_counter() - cell_start_perf
+                    failure_event = NotebookExecutionEvent(
+                        kind="cell_failed",
+                        notebook_path=source_path,
+                        output_path=final_output_path,
+                        cell_index=cell_index,
+                        code_cell_index=code_cell_index,
+                        total_code_cells=total_code_cells,
+                        cell_label=label,
+                        started_at=cell_started_at,
+                        finished_at=_utc_now(),
+                        elapsed_seconds=cell_elapsed,
+                        execution_count=_coerce_execution_count(cell),
+                        output_preview=_build_output_preview(cell),
+                        error_name=_extract_error_name(cell),
+                        error_value=_extract_error_value(cell),
+                    )
+                    cell_records.append(
+                        NotebookCellRecord(
+                            cell_index=cell_index,
+                            code_cell_index=code_cell_index,
+                            label=label,
+                            status="failed",
+                            elapsed_seconds=cell_elapsed,
+                            execution_count=_coerce_execution_count(cell),
+                            output_preview=_build_output_preview(cell),
+                        )
+                    )
+                    save_notebook_document(notebook, final_output_path)
+                    _notify(
+                        observer_tuple,
+                        NotebookExecutionEvent(
+                            kind="notebook_saved",
+                            notebook_path=source_path,
+                            output_path=final_output_path,
+                            total_code_cells=total_code_cells,
+                            finished_at=_utc_now(),
+                        ),
+                    )
+                    _notify(observer_tuple, failure_event)
+                    raise
+
+                cell_elapsed = time.perf_counter() - cell_start_perf
+                executed_code_cells += 1
+                cell_records.append(
+                    NotebookCellRecord(
+                        cell_index=cell_index,
+                        code_cell_index=code_cell_index,
+                        label=label,
+                        status="completed",
+                        elapsed_seconds=cell_elapsed,
+                        execution_count=_coerce_execution_count(cell),
+                        output_preview=_build_output_preview(cell),
+                    )
+                )
+                _notify(
+                    observer_tuple,
+                    NotebookExecutionEvent(
+                        kind="cell_completed",
+                        notebook_path=source_path,
+                        output_path=final_output_path,
+                        cell_index=cell_index,
+                        code_cell_index=code_cell_index,
+                        total_code_cells=total_code_cells,
+                        cell_label=label,
+                        started_at=cell_started_at,
+                        finished_at=_utc_now(),
+                        elapsed_seconds=cell_elapsed,
+                        execution_count=_coerce_execution_count(cell),
+                        output_preview=_build_output_preview(cell),
+                    ),
+                )
+                if save_every_cell:
+                    save_notebook_document(notebook, final_output_path)
+                    _notify(
+                        observer_tuple,
+                        NotebookExecutionEvent(
+                            kind="notebook_saved",
+                            notebook_path=source_path,
+                            output_path=final_output_path,
+                            cell_index=cell_index,
+                            code_cell_index=code_cell_index,
+                            total_code_cells=total_code_cells,
+                            cell_label=label,
+                            finished_at=_utc_now(),
+                        ),
+                    )
+    finally:
+        if not save_every_cell:
+            save_notebook_document(notebook, final_output_path)
+            _notify(
+                observer_tuple,
+                NotebookExecutionEvent(
+                    kind="notebook_saved",
+                    notebook_path=source_path,
+                    output_path=final_output_path,
+                    total_code_cells=total_code_cells,
+                    finished_at=_utc_now(),
+                ),
+            )
+
+    finished_at = _utc_now()
+    result = NotebookExecutionResult(
+        notebook_path=source_path,
+        output_path=final_output_path,
+        started_at=started_at,
+        finished_at=finished_at,
+        total_elapsed_seconds=time.perf_counter() - start_perf,
+        total_code_cells=total_code_cells,
+        executed_code_cells=executed_code_cells,
+        cell_records=tuple(cell_records),
+    )
+    _notify(
+        observer_tuple,
+        NotebookExecutionEvent(
+            kind="notebook_completed",
+            notebook_path=source_path,
+            output_path=final_output_path,
+            total_code_cells=total_code_cells,
+            started_at=started_at,
+            finished_at=finished_at,
+            elapsed_seconds=result.total_elapsed_seconds,
+        ),
+    )
+    return result
+
+
+def _notify(
+    observers: Sequence[NotebookExecutionObserver],
+    event: NotebookExecutionEvent,
+) -> None:
+    """Dispatch one event to all observers.
+
+    :param observers:
+        Event callback sequence.
+    :param event:
+        Event to emit.
+    :return:
+        None.
+    """
+
+    for observer in observers:
+        observer(event)
+
+
+def _validate_kernel_memory_limit(
+    memory_limit_bytes: int | None,
+) -> None:
+    """Validate a requested kernel memory cap.
+
+    :param memory_limit_bytes:
+        Desired address-space limit in bytes, or ``None`` to disable the cap.
+    :return:
+        None.
+    """
+
+    if memory_limit_bytes is None:
+        return
+    if memory_limit_bytes <= 0:
+        raise ValueError("kernel_memory_limit_bytes must be positive or None")
+
+
+@lru_cache(maxsize=16)
+def _kernel_memory_limit_is_supported(memory_limit_bytes: int | None) -> bool:
+    """Return whether this OS can launch Python under the requested cap.
+
+    Some systems expose Python ``resource`` constants but cannot lower virtual
+    memory limits to 24 GiB for a Python process. Probing through the same
+    ``ulimit`` wrapper keeps the production path a no-op on those systems.
+
+    :param memory_limit_bytes:
+        Desired address-space limit in bytes, or ``None`` to disable the cap.
+    :return:
+        ``True`` when the wrapper can start a tiny Python child.
+    """
+
+    if memory_limit_bytes is None or os.name != "posix":
+        return False
+    if not Path(_KERNEL_MEMORY_LIMIT_SHELL).exists():
+        return False
+
+    command = _wrap_kernel_command_with_memory_limit(
+        [sys.executable, "-c", "pass"],
+        memory_limit_bytes,
+    )
+    try:
+        result = subprocess.run(
+            command,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def _wrap_kernel_command_with_memory_limit(
+    kernel_cmd: list[str],
+    memory_limit_bytes: int,
+) -> list[str]:
+    """Wrap a kernel command so the shell lowers virtual memory before exec.
+
+    :param kernel_cmd:
+        Original Jupyter kernel command.
+    :param memory_limit_bytes:
+        Desired address-space limit in bytes.
+    :return:
+        Wrapped command suitable for ``subprocess.Popen``.
+    """
+
+    limit_kbytes = str(_bytes_to_kib(memory_limit_bytes))
+    return [
+        _KERNEL_MEMORY_LIMIT_SHELL,
+        "-c",
+        _KERNEL_MEMORY_LIMIT_SCRIPT,
+        "jupyter-memory-limit",
+        limit_kbytes,
+        *kernel_cmd,
+    ]
+
+
+def _bytes_to_kib(value: int) -> int:
+    """Convert bytes to ceiling-rounded kibibytes for ``ulimit -v``.
+
+    :param value:
+        Byte count.
+    :return:
+        Kibibyte count rounded up.
+    """
+
+    return (value + 1023) // 1024
+
+
+def _utc_now() -> datetime:
+    """Return the current UTC timestamp.
+
+    :return:
+        Timezone-aware UTC timestamp.
+    """
+
+    return datetime.now(timezone.utc)
+
+
+def _coerce_execution_count(cell: NotebookNode) -> int | None:
+    """Extract the execution count from a cell node.
+
+    :param cell:
+        Notebook cell node.
+    :return:
+        Integer execution count or ``None``.
+    """
+
+    execution_count = cell.get("execution_count")
+    return int(execution_count) if execution_count is not None else None
+
+
+def _build_output_preview(cell: NotebookNode, *, max_chars: int = 240) -> str | None:
+    """Build a compact output preview from a cell's outputs.
+
+    :param cell:
+        Notebook cell node.
+    :param max_chars:
+        Maximum preview length before truncation.
+    :return:
+        Output preview text or ``None`` if the cell has no text-like outputs.
+    """
+
+    fragments = [
+        preview
+        for output in cell.get("outputs", [])
+        if (preview := _build_single_output_preview(output, max_chars=max_chars)) is not None
+    ]
+    preview = " | ".join(fragment for fragment in fragments if fragment)
+    if not preview:
+        return None
+    if len(preview) <= max_chars:
+        return preview
+    return preview[: max_chars - 3] + "..."
+
+
+def _build_single_output_preview(output: NotebookNode, *, max_chars: int = 500) -> str | None:
+    """Build a compact preview from one Jupyter output payload.
+
+    :param output:
+        Jupyter output node.
+    :param max_chars:
+        Maximum preview length before truncation.
+    :return:
+        Output text preview or ``None`` when the payload has no text form.
+    """
+
+    output_type = output.get("output_type")
+    if output_type == "stream":
+        preview = _coerce_text_payload(output.get("text", "")).strip()
+    elif output_type == "widget_progress":
+        preview = _coerce_text_payload(output.get("text", "")).strip()
+    elif output_type in {"execute_result", "display_data"}:
+        data = output.get("data", {})
+        preview = _coerce_text_payload(data.get("text/plain", "")).strip()
+    elif output_type == "error":
+        traceback_lines = output.get("traceback", [])
+        if traceback_lines:
+            preview = _coerce_text_payload(traceback_lines[-1]).strip()
+        else:
+            preview = str(output.get("evalue", "")).strip()
+    else:
+        preview = ""
+    if not preview:
+        return None
+    if len(preview) <= max_chars:
+        return preview
+    return preview[: max_chars - 3] + "..."
+
+
+def _coerce_text_payload(value: object) -> str:
+    """Return text from notebook payload values that may be lists."""
+
+    if isinstance(value, list):
+        return "".join(str(item) for item in value)
+    return str(value)
+
+
+def _extract_error_name(cell: NotebookNode) -> str | None:
+    """Extract the last error name from a failed cell.
+
+    :param cell:
+        Notebook cell node.
+    :return:
+        Error name or ``None``.
+    """
+
+    for output in reversed(cell.get("outputs", [])):
+        if output.get("output_type") == "error":
+            error_name = output.get("ename")
+            return str(error_name) if error_name is not None else None
+    return None
+
+
+def _extract_error_value(cell: NotebookNode) -> str | None:
+    """Extract the last error value from a failed cell.
+
+    :param cell:
+        Notebook cell node.
+    :return:
+        Error value or ``None``.
+    """
+
+    for output in reversed(cell.get("outputs", [])):
+        if output.get("output_type") == "error":
+            error_value = output.get("evalue")
+            return str(error_value) if error_value is not None else None
+    return None

--- a/getting_started/jupyter_execute_agent/extension.py
+++ b/getting_started/jupyter_execute_agent/extension.py
@@ -1,0 +1,158 @@
+"""Reusable observer extensions for observable notebook execution.
+
+This module contains helpers that turn structured execution events into
+terminal- or logger-friendly messages. Keep these helpers separate from the
+core execution loop so they can be mixed, replaced, or composed by different
+callers.
+"""
+
+import logging
+
+from .core import NotebookExecutionEvent
+from .core import NotebookExecutionObserver
+
+__all__ = [
+    "build_logging_observer",
+    "format_execution_event",
+    "log_execution_event",
+]
+
+
+def format_execution_event(event: NotebookExecutionEvent) -> str:
+    """Format one execution event for human-readable logs.
+
+    Example:
+
+    .. code-block:: python
+
+        from getting_started.jupyter_execute_agent.extension import format_execution_event
+
+        message = format_execution_event(event)
+        print(message)
+
+    :param event:
+        Structured notebook execution event.
+    :return:
+        Single-line human-readable message.
+    """
+
+    if event.kind == "notebook_started":
+        return (
+            f"Notebook started path={event.notebook_path} "
+            f"code_cells={event.total_code_cells}"
+        )
+    if event.kind == "cell_started":
+        return (
+            f"Cell started {event.code_cell_index}/{event.total_code_cells} "
+            f"index={event.cell_index} label={event.cell_label}"
+        )
+    if event.kind == "cell_output":
+        output_suffix = f" output={event.output_preview}" if event.output_preview else ""
+        return (
+            f"Cell output {event.code_cell_index}/{event.total_code_cells} "
+            f"index={event.cell_index} type={event.output_type}"
+            f" label={event.cell_label}{output_suffix}"
+        )
+    if event.kind == "cell_completed":
+        output_suffix = (
+            f" output={event.output_preview}" if event.output_preview else ""
+        )
+        return (
+            f"Cell completed {event.code_cell_index}/{event.total_code_cells} "
+            f"index={event.cell_index} elapsed={event.elapsed_seconds:.2f}s"
+            f" label={event.cell_label}{output_suffix}"
+        )
+    if event.kind == "cell_failed":
+        return (
+            f"Cell failed {event.code_cell_index}/{event.total_code_cells} "
+            f"index={event.cell_index} elapsed={event.elapsed_seconds:.2f}s "
+            f"label={event.cell_label} error={event.error_name}: {event.error_value}"
+        )
+    if event.kind == "notebook_saved":
+        return f"Notebook saved path={event.output_path}"
+    if event.kind == "notebook_completed":
+        return (
+            f"Notebook completed path={event.output_path} "
+            f"elapsed={event.elapsed_seconds:.2f}s"
+        )
+    return f"Notebook event kind={event.kind}"
+
+
+def log_execution_event(
+    event: NotebookExecutionEvent,
+    *,
+    logger: logging.Logger | None = None,
+    level: int = logging.INFO,
+) -> None:
+    """Write one execution event through a standard logger.
+
+    Example:
+
+    .. code-block:: python
+
+        import logging
+        from getting_started.jupyter_execute_agent.extension import log_execution_event
+
+        logger = logging.getLogger("notebook-runner")
+        log_execution_event(event, logger=logger)
+
+    :param event:
+        Structured notebook execution event.
+    :param logger:
+        Logger to use. Defaults to this module's logger.
+    :param level:
+        Logging level used for the emitted message.
+    :return:
+        None.
+    """
+
+    active_logger = logger or logging.getLogger(__name__)
+    active_logger.log(level, "%s", format_execution_event(event))
+
+
+def build_logging_observer(
+    *,
+    logger: logging.Logger | None = None,
+    level: int = logging.INFO,
+    stream_cell_outputs: bool = True,
+) -> NotebookExecutionObserver:
+    """Build an observer callback that logs every execution event.
+
+    This is the simplest extension point for terminal-friendly notebook
+    execution. Pass the returned callback to
+    :func:`getting_started.jupyter_execute_agent.execute_notebook_observable`.
+
+    Example:
+
+    .. code-block:: python
+
+        import logging
+        from pathlib import Path
+
+        from getting_started.jupyter_execute_agent import execute_notebook_observable
+        from getting_started.jupyter_execute_agent.extension import build_logging_observer
+
+        observer = build_logging_observer(
+            logger=logging.getLogger("observable-notebook")
+        )
+        execute_notebook_observable(
+            Path("notebooks/demo.ipynb"),
+            observers=[observer],
+        )
+
+    :param logger:
+        Logger to receive execution messages. Defaults to this module's logger.
+    :param level:
+        Logging level used for every emitted event.
+    :param stream_cell_outputs:
+        Whether to log live output payloads while a cell is still running.
+    :return:
+        Observer callback suitable for ``execute_notebook_observable``.
+    """
+
+    def _observer(event: NotebookExecutionEvent) -> None:
+        if event.kind == "cell_output" and not stream_cell_outputs:
+            return
+        log_execution_event(event, logger=logger, level=level)
+
+    return _observer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dotenv = "^0.9.9"
 gym = "^0.26.2"
 ipdb = "^0.13.13"
 ipython = "<8"
+jupyter-client = "^8.6"  # Required by jupyter-execute-agent to manage the memory-capped notebook kernel
+nbclient = "^0.10"  # Required by jupyter-execute-agent for cell-by-cell observable notebook execution
 nbconvert = "^7.16.6"  # Required by notebook-static-server to render saved notebooks to HTML
 nbformat = "^5.10.4"  # Required by notebook-static-server to read .ipynb files
 parquet-cli = "^1.3"
@@ -43,6 +45,8 @@ pytest = "^7.0"
 
 [tool.poetry.scripts]
 notebook-static-server = "getting_started.notebook_static_server:main"
+# Preferred observable notebook runner for long research/backtest notebooks.
+jupyter-execute-agent = "getting_started.jupyter_execute_agent.cli:main"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_jupyter_execute_agent.py
+++ b/tests/test_jupyter_execute_agent.py
@@ -1,0 +1,84 @@
+"""Observability regression test for the ``jupyter-execute-agent`` runner.
+
+This exercises :func:`execute_notebook_observable` end-to-end on a tiny,
+self-contained notebook and asserts that the run is genuinely *observable*:
+the runner must stream a live cell-output event carrying the printed marker
+*before* it reports the cell as completed. This is the contract the observable
+runner exists to provide, so if it regresses this test fails.
+"""
+
+from pathlib import Path
+
+import nbformat
+
+from getting_started.jupyter_execute_agent import execute_notebook_observable
+
+
+def _write_simple_notebook(notebook_path: Path) -> None:
+    """Write a one-cell notebook that prints an observable marker."""
+
+    notebook = nbformat.v4.new_notebook(
+        cells=[
+            nbformat.v4.new_code_cell("print('observable-marker')"),
+        ],
+        metadata={
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3",
+            },
+            "language_info": {"name": "python"},
+        },
+    )
+    with notebook_path.open("w", encoding="utf-8") as handle:
+        nbformat.write(notebook, handle)
+
+
+def test_notebook_run_is_observable(tmp_path: Path) -> None:
+    """A simple notebook run must stream live output before completion."""
+
+    notebook_path = tmp_path / "simple.ipynb"
+    output_path = tmp_path / "simple-executed.ipynb"
+    _write_simple_notebook(notebook_path)
+
+    observed_events: list[tuple[str, str | None]] = []
+
+    def observer(event) -> None:
+        observed_events.append((event.kind, event.output_preview))
+
+    result = execute_notebook_observable(
+        notebook_path,
+        output_path=output_path,
+        timeout=60,
+        observers=[observer],
+    )
+
+    # The notebook executed fully.
+    assert result.executed_code_cells == 1
+    assert result.total_code_cells == 1
+
+    event_kinds = [kind for kind, _ in observed_events]
+
+    # Lifecycle events are emitted, which is what makes the run observable.
+    assert "notebook_started" in event_kinds
+    assert "cell_started" in event_kinds
+    assert "cell_completed" in event_kinds
+    assert "notebook_completed" in event_kinds
+
+    # The printed marker is streamed as a live output event...
+    assert any(
+        kind == "cell_output" and preview == "observable-marker"
+        for kind, preview in observed_events
+    )
+
+    # ...and it arrives before the cell is reported as completed.
+    assert event_kinds.index("cell_output") < event_kinds.index("cell_completed")
+
+    # The executed notebook was saved with the marker in its outputs.
+    executed = nbformat.read(output_path, as_version=4)
+    stream_text = "".join(
+        str(output.get("text", ""))
+        for output in executed.cells[0].get("outputs", [])
+        if output.get("output_type") == "stream"
+    )
+    assert "observable-marker" in stream_text


### PR DESCRIPTION
## Summary

Ports the observable notebook execution agent from `freqtrade-strategies` into this repo so agents can watch long backtest/optimiser notebook runs.

`jupyter-execute-agent` keeps the Jupyter-kernel execution model but streams notebook- and cell-level progress, live cell output previews, and live `tqdm` progress text, saving the notebook after every completed cell (so a crash still leaves every output up to the failing cell). It also applies a 24 GiB kernel memory cap where the OS shell supports it.

## Changes

- **`getting_started/jupyter_execute_agent/`** — the runner package (core execution loop, CLI, logging observers).
- **`pyproject.toml`** — `jupyter-execute-agent` console script; explicit `nbclient` / `jupyter-client` deps it imports directly.
- **`.claude/docs/notebook-execution.md`** — command reference and observability requirements.
- **`CLAUDE.md`** — `jupyter-execute-agent` is now the preferred notebook entrypoint (plain `jupyter execute` kept as fallback).
- **`tests/test_jupyter_execute_agent.py`** — regression test that runs a simple notebook and asserts the run is observable (live `cell_output` arrives before `cell_completed`, notebook saved with output).
- **Skills** — `convert-to-backtest`, `convert-to-optimiser`, `create-variant`, `run-variant-cycle` now run notebooks via `jupyter-execute-agent`.

> Note: the `jupyter-execute-agent` shell command becomes available after `poetry install` registers the console script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)